### PR TITLE
Fix disallowing adding yourself as a favorite

### DIFF
--- a/cogs/favorites.py
+++ b/cogs/favorites.py
@@ -104,6 +104,8 @@ class FavoriteCog(commands.Cog):
 
         to_add = []
         for u in msg.mentions:
+            if u.id == msg.author.id:
+                continue
             to_add.append(u)
         for u in msg.content.split():
             try:


### PR DESCRIPTION
I haven't tested this myself (I haven't setup the tipbot locally), but this is my guess as to the problem and the fix.