### PR TITLE
Make user started giveaways add to tipstats

### DIFF
--- a/cogs/giveaway.py
+++ b/cogs/giveaway.py
@@ -361,6 +361,9 @@ class GiveawayCog(commands.Cog):
                         giveaway=gw,
                         conn=conn
                     )
+                    # Update stats
+                    stats: Stats = await user.get_stats(server_id=msg.guild.id)
+                    await stats.update_tip_stats(giveaway_amount)
                 # Announce giveaway
                 embed = self.format_giveaway_announcement(gw)
                 await msg.channel.send(embed=embed)


### PR DESCRIPTION
As user sponsored giveaways are now different from the auto giveaways, it makes sense to add the sponsor amount to tipstats.