### PR TITLE
Allow primates to use admin commands

### DIFF
--- a/kubernetes/graham_banano/configmap.yaml
+++ b/kubernetes/graham_banano/configmap.yaml
@@ -16,6 +16,7 @@ data:
       - 431126363261370392
       - 557648182872375318
       - 430732639130091541
+      - 655495981323911218
     
     restrictions:
       # Channel IDs that the bot won't post publicly in


### PR DESCRIPTION
Primates delegate allowance funds to users and should be able to subtract when distributing via proxies