### PR TITLE
Add Russia and Ukraine jungles to announce list

### DIFF
--- a/kubernetes/bananobot/configmap.yaml
+++ b/kubernetes/bananobot/configmap.yaml
@@ -84,6 +84,8 @@ data:
         - 772489489095589898
         - 793847273381298238
         - 798855842576597012
+        - 1087029371174400113
+        - 1087032376414179379
       # Some giveaway commands are deleted to prevent them from clogging up the chat
       # Put channels here where you dont want them to be deleted.
       no_delete_channels:


### PR DESCRIPTION
Russian language channel was split up into two new channels due to the ongoing conflict.