### PR TITLE
Change block explorer for Nano

### DIFF
--- a/cogs/spy.py
+++ b/cogs/spy.py
@@ -62,7 +62,7 @@ class SpyCog(commands.Cog):
             if Env.banano():
                 response += f"https://creeper.banano.cc/explorer/account/{u.account.address}\n"
             else:
-                response += f"https://nanocrawler.cc/explorer/account/{u.account.address}\n"
+                response += f"https://blocklattice.io/account/{u.account.address}\n"
 
         embed = discord.Embed(colour=0xFBDD11 if Env.banano() else discord.Colour.dark_blue())
         embed.set_author(name="WFU Result", icon_url="https://github.com/bbedward/graham_discord_bot/raw/master/assets/banano_logo.png" if Env.banano() else "https://github.com/bbedward/graham_discord_bot/raw/master/assets/nano_logo.png")

--- a/tasks/transaction_queue.py
+++ b/tasks/transaction_queue.py
@@ -47,7 +47,7 @@ class TransactionQueue(object):
         if Env.banano():
             await user.send(f"Withdraw processed: https://creeper.banano.cc/explorer/block/{hash}")
         else:
-            await user.send(f"Withdraw processed: https://nanocrawler.cc/explorer/block/{hash}")
+            await user.send(f"Withdraw processed: https://blocklattice.io/block/{hash}")
 
     async def retry(self, tx: Transaction):
         delay = tx.retries + 1 * 5


### PR DESCRIPTION
Original Nanocrawler is no longer accessible. nanoblockexplorer.com doesn't work properly.
This PR changes it to Blocklattice.