### PR TITLE
Update burn

### DIFF
--- a/cogs/tips.py
+++ b/cogs/tips.py
@@ -116,7 +116,6 @@ class TipsCog(commands.Cog):
 
     @commands.command()
     async def burn(self, ctx: Context):
-        return
         msg = ctx.message
         user = ctx.user
         send_amount = ctx.send_amount


### PR DESCRIPTION
Remove a "return" to let the command execute. It exits immediately because of the "return", so burn command doesn't do anything.