### PR TITLE
Update burn command and author's Discord handle

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -147,7 +147,7 @@ class HelpCog(commands.Cog):
         description = "This bot is completely free, open source, and MIT licensed"
         description+= f"\n\nMade with {heart} for the **BANANO** and **NANO** communities"
         description+= f"\nHangout with some awesome people at https://chat.banano.cc"
-        description+= f"\nMy Discord: **@bbedward#9246**"
+        description+= f"\nMy Discord: **bbedward**"
         description+= f"\nMy Reddit: **/u/bbedward**"
         description+= f"\nMy Twitter: **@theRealBbedward**"
         description+= f"\n\nGraham GitHub: https://github.com/bbedward/graham_discord_bot"

--- a/cogs/tips.py
+++ b/cogs/tips.py
@@ -116,7 +116,6 @@ class TipsCog(commands.Cog):
 
     @commands.command()
     async def burn(self, ctx: Context):
-        return
         msg = ctx.message
         user = ctx.user
         send_amount = ctx.send_amount


### PR DESCRIPTION
Remove a "return" to let the command execute. It exits immediately with the "return", so the burn command does nothing.

Discord removed the discriminator, this PR updates the author's username.